### PR TITLE
Fixed compilation error for 0.1.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/mattn/go-pointer v0.0.1
-	github.com/tinyzimmer/go-glib v0.0.3
+	github.com/tinyzimmer/go-glib v0.0.2
 )

--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -752,7 +752,7 @@ func (p *Pad) QueryPosition(format Format) (bool, int64) {
 
 // RemoveProbe removes the probe with id from pad.
 func (p *Pad) RemoveProbe(id uint64) {
-	C.gst_pad_remove_probe(p.Instance(), C.guint64(id))
+	C.gst_pad_remove_probe(p.Instance(), C.gulong(id))
 }
 
 // SendEvent sends the event to the pad. This function can be used by applications to send events in the pipeline.

--- a/gst/video/gst_color_balance.go
+++ b/gst/video/gst_color_balance.go
@@ -1,6 +1,7 @@
 package video
 
 /*
+#include <stdlib.h>
 #include <gst/gst.h>
 #include <gst/video/video.h>
 

--- a/gst/video/gst_navigation.go
+++ b/gst/video/gst_navigation.go
@@ -1,6 +1,7 @@
 package video
 
 /*
+#include <stdlib.h>
 #include <gst/video/video.h>
 
 GstNavigation * toGstNavigation (GstElement * element)


### PR DESCRIPTION
Just reference to the changes needed to compile version 0.1.10 on Windows machine. 

Note: I think the changes @tinyzimmer made to the glib library needs to be undone, since those handler should take in gulong and not gsize. 