### PR TITLE
Modified gst_pad.go c function cgoGstPadActivateModeFunction

### DIFF
--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -35,7 +35,7 @@ gboolean
 cgoGstPadActivateFunction(GstPad * pad, GstObject * parent) { return goGstPadActivateFunction(pad, parent); }
 
 gboolean
-cgoGstPadActivateModeFunction (GstPad * pad, GstObject * parent, GstPadMode mode, gboolean active) { return cgoGstPadActivateModeFunction(pad, parent, mode, active); }
+cgoGstPadActivateModeFunction (GstPad * pad, GstObject * parent, GstPadMode mode, gboolean active) { return goGstPadActivateModeFunction(pad, parent, mode, active); }
 
 GstFlowReturn
 cgoGstPadChainFunction (GstPad * pad, GstObject * parent, GstBuffer * buffer) { return goGstPadChainFunction(pad, parent, buffer); }


### PR DESCRIPTION
Modified to call goGstPadActivateModeFunction instead of cgoGstPadActivateModeFunction which would be itself.