### PR TITLE
Debugger Enablement

### DIFF
--- a/gst/app/gst.go.c
+++ b/gst/app/gst.go.c
@@ -1,0 +1,5 @@
+#include "gst.go.h"
+
+GstAppSink *  toGstAppSink   (void *p) { return (GST_APP_SINK(p)); }
+GstAppSrc *   toGstAppSrc    (void *p) { return (GST_APP_SRC(p)); }
+

--- a/gst/app/gst.go.h
+++ b/gst/app/gst.go.h
@@ -4,7 +4,7 @@
 #include <gst/app/gstappsink.h>
 #include <gst/app/gstappsrc.h>
 
-inline GstAppSink *  toGstAppSink   (void *p) { return (GST_APP_SINK(p)); }
-inline GstAppSrc *   toGstAppSrc    (void *p) { return (GST_APP_SRC(p)); }
+extern GstAppSink *  toGstAppSink   (void *p);
+extern GstAppSrc *   toGstAppSrc    (void *p);
 
 #endif

--- a/gst/base/gst.go.c
+++ b/gst/base/gst.go.c
@@ -1,0 +1,15 @@
+#include "gst.go.h"
+
+GstBaseSink *       toGstBaseSink       (void *p)    { return GST_BASE_SINK_CAST(p); }
+GstBaseSrc *        toGstBaseSrc        (void *p)    { return GST_BASE_SRC_CAST(p); }
+GstBaseTransform *  toGstBaseTransform  (void *p)    { return GST_BASE_TRANSFORM(p); }
+GstCollectPads *    toGstCollectPads    (void *p)    { return GST_COLLECT_PADS(p); }
+GstPushSrc *        toGstPushSrc        (void *p)    { return GST_PUSH_SRC(p); }
+
+GstBaseSinkClass *       toGstBaseSinkClass       (void *p) { return (GstBaseSinkClass *)p; }
+GstBaseSrcClass *        toGstBaseSrcClass        (void *p) { return (GstBaseSrcClass  *)p; }
+GstBaseTransformClass *  toGstBaseTransformClass  (void *p) { return (GstBaseTransformClass *)p; }
+GstPushSrcClass *        toGstPushSrcClass        (void *p) { return (GstPushSrcClass *)p; }
+
+gint64  gstCollectDataDTS  (GstCollectData * gcd)  { return GST_COLLECT_PADS_DTS(gcd); }
+

--- a/gst/base/gst.go.h
+++ b/gst/base/gst.go.h
@@ -4,17 +4,17 @@
 #include <gst/base/base.h>
 #include <stddef.h>
 
-inline GstBaseSink *       toGstBaseSink       (void *p)    { return GST_BASE_SINK_CAST(p); }
-inline GstBaseSrc *        toGstBaseSrc        (void *p)    { return GST_BASE_SRC_CAST(p); }
-inline GstBaseTransform *  toGstBaseTransform  (void *p)    { return GST_BASE_TRANSFORM(p); }
-inline GstCollectPads *    toGstCollectPads    (void *p)    { return GST_COLLECT_PADS(p); }
-inline GstPushSrc *        toGstPushSrc        (void *p)    { return GST_PUSH_SRC(p); }
+extern GstBaseSink *       toGstBaseSink       (void *p);
+extern GstBaseSrc *        toGstBaseSrc        (void *p);
+extern GstBaseTransform *  toGstBaseTransform  (void *p);
+extern GstCollectPads *    toGstCollectPads    (void *p);
+extern GstPushSrc *        toGstPushSrc        (void *p);
 
-inline GstBaseSinkClass *       toGstBaseSinkClass       (void *p) { return (GstBaseSinkClass *)p; }
-inline GstBaseSrcClass *        toGstBaseSrcClass        (void *p) { return (GstBaseSrcClass  *)p; }
-inline GstBaseTransformClass *  toGstBaseTransformClass  (void *p) { return (GstBaseTransformClass *)p; }
-inline GstPushSrcClass *        toGstPushSrcClass        (void *p) { return (GstPushSrcClass *)p; }
+extern GstBaseSinkClass *       toGstBaseSinkClass       (void *p);
+extern GstBaseSrcClass *        toGstBaseSrcClass        (void *p);
+extern GstBaseTransformClass *  toGstBaseTransformClass  (void *p);
+extern GstPushSrcClass *        toGstPushSrcClass        (void *p);
 
-inline gint64  gstCollectDataDTS  (GstCollectData * gcd)  { return GST_COLLECT_PADS_DTS(gcd); }
+extern gint64  gstCollectDataDTS  (GstCollectData * gcd);
 
 #endif

--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -1,0 +1,172 @@
+#include "gst.go.h"
+
+GType                  objectGType            (GObject *obj) { return G_OBJECT_TYPE(obj); };
+GObjectClass *         toGObjectClass         (void *p)      { return (G_OBJECT_CLASS(p)); }
+
+GstAllocator *         toGstAllocator         (void *p) { return (GST_ALLOCATOR_CAST(p)); }
+GstBin *               toGstBin               (void *p) { return (GST_BIN(p)); }
+GstBinClass *          toGstBinClass          (void *p) { return (GST_BIN_CLASS(p)); }
+GstBufferList *        toGstBufferList        (void *p) { return (GST_BUFFER_LIST(p)); }
+GstBufferPool *        toGstBufferPool        (void *p) { return (GST_BUFFER_POOL(p)); }
+GstBuffer *            toGstBuffer            (void *p) { return (GST_BUFFER(p)); }
+GstBus *               toGstBus               (void *p) { return (GST_BUS(p)); }
+GstCapsFeatures *      toGstCapsFeatures      (void *p) { return (GST_CAPS_FEATURES(p)); }
+GstCaps *              toGstCaps              (void *p) { return (GST_CAPS(p)); }
+GstChildProxy *        toGstChildProxy        (void *p) { return (GST_CHILD_PROXY(p)); }
+GstClock *             toGstClock             (void *p) { return (GST_CLOCK(p)); }
+GstContext *           toGstContext           (void *p) { return (GST_CONTEXT_CAST(p)); }
+GstDevice *            toGstDevice            (void *p) { return (GST_DEVICE_CAST(p)); }
+GstElementFactory *    toGstElementFactory    (void *p) { return (GST_ELEMENT_FACTORY(p)); }
+GstElementClass *      toGstElementClass      (void *p) { return (GST_ELEMENT_CLASS(p)); }
+GstElement *           toGstElement           (void *p) { return (GST_ELEMENT(p)); }
+GstEvent *             toGstEvent             (void *p) { return (GST_EVENT(p)); }
+GstGhostPad *          toGstGhostPad          (void *p) { return (GST_GHOST_PAD(p)); }
+GstMemory *            toGstMemory            (void *p) { return (GST_MEMORY_CAST(p)); }
+GstMessage *           toGstMessage           (void *p) { return (GST_MESSAGE(p)); }
+GstMeta *              toGstMeta              (void *p) { return (GST_META_CAST(p)); }
+GstMiniObject *        toGstMiniObject        (void *p) { return (GST_MINI_OBJECT(p)); }
+GstObject *            toGstObject            (void *p) { return (GST_OBJECT(p)); }
+GstPad *               toGstPad               (void *p) { return (GST_PAD(p)); }
+GstPadTemplate *       toGstPadTemplate       (void *p) { return (GST_PAD_TEMPLATE(p)); }
+GstPipeline *          toGstPipeline          (void *p) { return (GST_PIPELINE(p)); }
+GstPluginFeature *     toGstPluginFeature     (void *p) { return (GST_PLUGIN_FEATURE(p)); }
+GstPlugin *            toGstPlugin            (void *p) { return (GST_PLUGIN(p)); }
+GstProxyPad *          toGstProxyPad          (void *p) { return (GST_PROXY_PAD(p)); }
+GstQuery *             toGstQuery             (void *p) { return (GST_QUERY(p)); }
+GstRegistry *          toGstRegistry          (void *p) { return (GST_REGISTRY(p)); }
+GstSample *            toGstSample            (void *p) { return (GST_SAMPLE(p)); }
+GstStreamCollection *  toGstStreamCollection  (void *p) { return (GST_STREAM_COLLECTION_CAST(p)); }
+GstStream *            toGstStream            (void *p) { return (GST_STREAM_CAST(p)); }
+GstStructure *         toGstStructure         (void *p) { return (GST_STRUCTURE(p)); }
+GstTagList   *         toGstTagList           (void *p) { return (GST_TAG_LIST(p)); }
+GstTask *              toGstTask              (void *p) { return (GST_TASK_CAST(p)); }
+GstTaskPool *          toGstTaskPool          (void *p) { return (GST_TASK_POOL_CAST(p)); }
+GstURIHandler *        toGstURIHandler        (void *p) { return (GST_URI_HANDLER(p)); }
+GstUri *               toGstURI               (void *p) { return (GST_URI(p)); }
+
+/* Buffer Utilities */
+
+GstBuffer * getBufferValue (GValue * val)
+{
+	return gst_value_get_buffer(val);
+}
+
+gboolean bufferIsWritable (GstBuffer * buf)
+{
+	return (gst_buffer_is_writable(buf));
+}
+
+GstBuffer * makeBufferWritable (GstBuffer * buf)
+{
+	return (gst_buffer_make_writable(buf));
+}
+
+GType bufferListType ()
+{
+	return GST_TYPE_BUFFER_LIST;
+}
+
+/* BufferList Utilities */
+
+gboolean bufferListIsWritable (GstBufferList * bufList)
+{
+	return gst_buffer_list_is_writable(bufList);
+}
+
+GstBufferList * makeBufferListWritable (GstBufferList * bufList)
+{
+	return gst_buffer_list_make_writable(bufList);
+}
+
+void addToBufferList (GstBufferList * bufList, GstBuffer * buf)
+{
+	gst_buffer_list_add(bufList, buf);
+}
+
+/* BufferPool utilities */
+
+gboolean bufferPoolIsFlushing (GstBufferPool * pool)
+{
+	return GST_BUFFER_POOL_IS_FLUSHING(pool);
+}
+
+/* Caps utilties */
+
+gboolean capsIsWritable (GstCaps * caps)
+{
+	return gst_caps_is_writable(caps);
+}
+
+GstCaps * makeCapsWritable (GstCaps * caps)
+{
+	return gst_caps_make_writable(caps);
+}
+
+/* Context utilities */
+
+gboolean contextIsWritable (GstContext * ctx)
+{
+	return gst_context_is_writable(ctx);
+}
+
+GstContext * makeContextWritable (GstContext * ctx)
+{
+	return gst_context_make_writable(ctx);
+}
+
+/* Event Utilities */
+
+gboolean eventIsWritable (GstEvent * event)
+{
+	return gst_event_is_writable(event);
+}
+
+GstEvent * makeEventWritable (GstEvent * event)
+{
+	return gst_event_make_writable(event);
+}
+
+/* TOC Utilities */
+
+gboolean         entryTypeIsAlternative (GstTocEntryType * type) { return GST_TOC_ENTRY_TYPE_IS_ALTERNATIVE(type); }
+gboolean         entryTypeIsSequence    (GstTocEntryType * type) { return GST_TOC_ENTRY_TYPE_IS_SEQUENCE(type); }
+GstTocEntry *    copyTocEntry           (GstTocEntry * entry)    { return gst_toc_entry_copy(entry); }
+GstTocEntry *    makeTocEntryWritable   (GstTocEntry * entry)    { return gst_toc_entry_make_writable(entry); }
+GstTocEntry *    tocEntryRef            (GstTocEntry * entry)    { return gst_toc_entry_ref(entry); }
+void             tocEntryUnref          (GstTocEntry * entry)    { gst_toc_entry_unref(entry); }
+GstToc *         copyToc                (GstToc * toc)           { return gst_toc_copy(toc); }
+GstToc *         makeTocWritable        (GstToc * toc)           { return gst_toc_make_writable(toc); }
+GstToc *         tocRef                 (GstToc * toc)           { return gst_toc_ref(toc); }
+void             tocUnref               (GstToc * toc)           { gst_toc_unref(toc); }
+
+/* TagList utilities */
+
+gboolean         tagListIsWritable     (GstTagList * tagList)   { return gst_tag_list_is_writable(tagList); }
+GstTagList *     makeTagListWritable   (GstTagList * tagList)   { return gst_tag_list_make_writable(tagList); }
+
+/* Object Utilities */
+
+GObjectClass *  getGObjectClass         (void * p)                               { return (G_OBJECT_GET_CLASS(p)); }
+gboolean        gstElementIsURIHandler  (GstElement * elem)                      { return (GST_IS_URI_HANDLER(elem)); }
+gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags) { return (GST_OBJECT_FLAG_IS_SET(obj, flags)); }
+
+/* Element utilities */
+
+GstTocSetter *  toTocSetter (GstElement * elem) { return GST_TOC_SETTER(elem); }
+GstTagSetter *  toTagSetter (GstElement *elem)  { return GST_TAG_SETTER(elem); }
+
+
+/* Misc */
+
+gpointer glistNext (GList * list)
+{
+	return g_list_next(list);
+}
+
+int sizeOfGCharArray (gchar ** arr)
+{
+	int i;
+	for (i = 0 ; 1 ; i = i + 1) {
+		if (arr[i] == NULL) { return i; };
+	}
+}

--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -1,7 +1,6 @@
 #include "gst.go.h"
 
 GType                  objectGType            (GObject *obj) { return G_OBJECT_TYPE(obj); };
-GObjectClass *         toGObjectClass         (void *p)      { return (G_OBJECT_CLASS(p)); }
 
 GstAllocator *         toGstAllocator         (void *p) { return (GST_ALLOCATOR_CAST(p)); }
 GstBin *               toGstBin               (void *p) { return (GST_BIN(p)); }
@@ -146,7 +145,6 @@ GstTagList *     makeTagListWritable   (GstTagList * tagList)   { return gst_tag
 
 /* Object Utilities */
 
-GObjectClass *  getGObjectClass         (void * p)                               { return (G_OBJECT_GET_CLASS(p)); }
 gboolean        gstElementIsURIHandler  (GstElement * elem)                      { return (GST_IS_URI_HANDLER(elem)); }
 gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags) { return (GST_OBJECT_FLAG_IS_SET(obj, flags)); }
 

--- a/gst/gst.go.h
+++ b/gst/gst.go.h
@@ -14,175 +14,124 @@ typedef struct _PadDestroyNotifyInfo {
 	Type Castings
 */
 
-inline GType                  objectGType            (GObject *obj) { return G_OBJECT_TYPE(obj); };
-inline GObjectClass *         toGObjectClass         (void *p)      { return (G_OBJECT_CLASS(p)); }
+extern GType                  objectGType            (GObject *obj);
+extern GObjectClass *         toGObjectClass         (void *p);
 
-inline GstAllocator *         toGstAllocator         (void *p) { return (GST_ALLOCATOR_CAST(p)); }
-inline GstBin *               toGstBin               (void *p) { return (GST_BIN(p)); }
-inline GstBinClass *          toGstBinClass          (void *p) { return (GST_BIN_CLASS(p)); }
-inline GstBufferList *        toGstBufferList        (void *p) { return (GST_BUFFER_LIST(p)); }
-inline GstBufferPool *        toGstBufferPool        (void *p) { return (GST_BUFFER_POOL(p)); }
-inline GstBuffer *            toGstBuffer            (void *p) { return (GST_BUFFER(p)); }
-inline GstBus *               toGstBus               (void *p) { return (GST_BUS(p)); }
-inline GstCapsFeatures *      toGstCapsFeatures      (void *p) { return (GST_CAPS_FEATURES(p)); }
-inline GstCaps *              toGstCaps              (void *p) { return (GST_CAPS(p)); }
-inline GstChildProxy *        toGstChildProxy        (void *p) { return (GST_CHILD_PROXY(p)); }
-inline GstClock *             toGstClock             (void *p) { return (GST_CLOCK(p)); }
-inline GstContext *           toGstContext           (void *p) { return (GST_CONTEXT_CAST(p)); }
-inline GstDevice *            toGstDevice            (void *p) { return (GST_DEVICE_CAST(p)); }
-inline GstElementFactory *    toGstElementFactory    (void *p) { return (GST_ELEMENT_FACTORY(p)); }
-inline GstElementClass *      toGstElementClass      (void *p) { return (GST_ELEMENT_CLASS(p)); }
-inline GstElement *           toGstElement           (void *p) { return (GST_ELEMENT(p)); }
-inline GstEvent *             toGstEvent             (void *p) { return (GST_EVENT(p)); }
-inline GstGhostPad *          toGstGhostPad          (void *p) { return (GST_GHOST_PAD(p)); }
-inline GstMemory *            toGstMemory            (void *p) { return (GST_MEMORY_CAST(p)); }
-inline GstMessage *           toGstMessage           (void *p) { return (GST_MESSAGE(p)); }
-inline GstMeta *              toGstMeta              (void *p) { return (GST_META_CAST(p)); }
-inline GstMiniObject *        toGstMiniObject        (void *p) { return (GST_MINI_OBJECT(p)); }
-inline GstObject *            toGstObject            (void *p) { return (GST_OBJECT(p)); }
-inline GstPad *               toGstPad               (void *p) { return (GST_PAD(p)); }
-inline GstPadTemplate *       toGstPadTemplate       (void *p) { return (GST_PAD_TEMPLATE(p)); }
-inline GstPipeline *          toGstPipeline          (void *p) { return (GST_PIPELINE(p)); }
-inline GstPluginFeature *     toGstPluginFeature     (void *p) { return (GST_PLUGIN_FEATURE(p)); }
-inline GstPlugin *            toGstPlugin            (void *p) { return (GST_PLUGIN(p)); }
-inline GstProxyPad *          toGstProxyPad          (void *p) { return (GST_PROXY_PAD(p)); }
-inline GstQuery *             toGstQuery             (void *p) { return (GST_QUERY(p)); }
-inline GstRegistry *          toGstRegistry          (void *p) { return (GST_REGISTRY(p)); }
-inline GstSample *            toGstSample            (void *p) { return (GST_SAMPLE(p)); }
-inline GstStreamCollection *  toGstStreamCollection  (void *p) { return (GST_STREAM_COLLECTION_CAST(p)); }
-inline GstStream *            toGstStream            (void *p) { return (GST_STREAM_CAST(p)); }
-inline GstStructure *         toGstStructure         (void *p) { return (GST_STRUCTURE(p)); }
-inline GstTagList   *         toGstTagList           (void *p) { return (GST_TAG_LIST(p)); }
-inline GstTask *              toGstTask              (void *p) { return (GST_TASK_CAST(p)); }
-inline GstTaskPool *          toGstTaskPool          (void *p) { return (GST_TASK_POOL_CAST(p)); }
-inline GstURIHandler *        toGstURIHandler        (void *p) { return (GST_URI_HANDLER(p)); }
-inline GstUri *               toGstURI               (void *p) { return (GST_URI(p)); }
+extern GstAllocator *         toGstAllocator         (void *p);
+extern GstBin *               toGstBin               (void *p);
+extern GstBinClass *          toGstBinClass          (void *p);
+extern GstBufferList *        toGstBufferList        (void *p);
+extern GstBufferPool *        toGstBufferPool        (void *p);
+extern GstBuffer *            toGstBuffer            (void *p);
+extern GstBus *               toGstBus               (void *p);
+extern GstCapsFeatures *      toGstCapsFeatures      (void *p);
+extern GstCaps *              toGstCaps              (void *p);
+extern GstChildProxy *        toGstChildProxy        (void *p);
+extern GstClock *             toGstClock             (void *p);
+extern GstContext *           toGstContext           (void *p);
+extern GstDevice *            toGstDevice            (void *p);
+extern GstElementFactory *    toGstElementFactory    (void *p);
+extern GstElementClass *      toGstElementClass      (void *p);
+extern GstElement *           toGstElement           (void *p);
+extern GstEvent *             toGstEvent             (void *p);
+extern GstGhostPad *          toGstGhostPad          (void *p);
+extern GstMemory *            toGstMemory            (void *p);
+extern GstMessage *           toGstMessage           (void *p);
+extern GstMeta *              toGstMeta              (void *p);
+extern GstMiniObject *        toGstMiniObject        (void *p);
+extern GstObject *            toGstObject            (void *p);
+extern GstPad *               toGstPad               (void *p);
+extern GstPadTemplate *       toGstPadTemplate       (void *p);
+extern GstPipeline *          toGstPipeline          (void *p);
+extern GstPluginFeature *     toGstPluginFeature     (void *p);
+extern GstPlugin *            toGstPlugin            (void *p);
+extern GstProxyPad *          toGstProxyPad          (void *p);
+extern GstQuery *             toGstQuery             (void *p);
+extern GstRegistry *          toGstRegistry          (void *p);
+extern GstSample *            toGstSample            (void *p);
+extern GstStreamCollection *  toGstStreamCollection  (void *p);
+extern GstStream *            toGstStream            (void *p);
+extern GstStructure *         toGstStructure         (void *p);
+extern GstTagList   *         toGstTagList           (void *p);
+extern GstTask *              toGstTask              (void *p);
+extern GstTaskPool *          toGstTaskPool          (void *p);
+extern GstURIHandler *        toGstURIHandler        (void *p);
+extern GstUri *               toGstURI               (void *p);
 
 /* Buffer Utilities */
 
-inline GstBuffer * getBufferValue (GValue * val)
-{
-	return gst_value_get_buffer(val);
-}
+extern GstBuffer * getBufferValue (GValue * val);
 
-inline gboolean bufferIsWritable (GstBuffer * buf)
-{
-	return (gst_buffer_is_writable(buf));
-}
+extern gboolean bufferIsWritable (GstBuffer * buf);
 
-inline GstBuffer * makeBufferWritable (GstBuffer * buf)
-{
-	return (gst_buffer_make_writable(buf));
-}
+extern GstBuffer * makeBufferWritable (GstBuffer * buf);
 
-inline GType bufferListType ()
-{
-	return GST_TYPE_BUFFER_LIST;
-}
+extern GType bufferListType ();
 
 /* BufferList Utilities */
 
-inline gboolean bufferListIsWritable (GstBufferList * bufList)
-{
-	return gst_buffer_list_is_writable(bufList);
-}
+extern gboolean bufferListIsWritable (GstBufferList * bufList);
 
-inline GstBufferList * makeBufferListWritable (GstBufferList * bufList)
-{
-	return gst_buffer_list_make_writable(bufList);
-}
+extern GstBufferList * makeBufferListWritable (GstBufferList * bufList);
 
-inline void addToBufferList (GstBufferList * bufList, GstBuffer * buf)
-{
-	gst_buffer_list_add(bufList, buf);
-}
+extern void addToBufferList (GstBufferList * bufList, GstBuffer * buf);
 
 /* BufferPool utilities */
 
-inline gboolean bufferPoolIsFlushing (GstBufferPool * pool)
-{
-	return GST_BUFFER_POOL_IS_FLUSHING(pool);
-}
+extern gboolean bufferPoolIsFlushing (GstBufferPool * pool);
 
 /* Caps utilties */
 
-inline gboolean capsIsWritable (GstCaps * caps)
-{
-	return gst_caps_is_writable(caps);
-}
+extern gboolean capsIsWritable (GstCaps * caps);
 
-inline GstCaps * makeCapsWritable (GstCaps * caps)
-{
-	return gst_caps_make_writable(caps);
-}
+extern GstCaps * makeCapsWritable (GstCaps * caps);
 
 /* Context utilities */
 
-inline gboolean contextIsWritable (GstContext * ctx)
-{
-	return gst_context_is_writable(ctx);
-}
+extern gboolean contextIsWritable (GstContext * ctx);
 
-inline GstContext * makeContextWritable (GstContext * ctx)
-{
-	return gst_context_make_writable(ctx);
-}
+extern GstContext * makeContextWritable (GstContext * ctx);
 
 /* Event Utilities */
 
-inline gboolean eventIsWritable (GstEvent * event)
-{
-	return gst_event_is_writable(event);
-}
+extern gboolean eventIsWritable (GstEvent * event);
 
-inline GstEvent * makeEventWritable (GstEvent * event)
-{
-	return gst_event_make_writable(event);
-}
+extern GstEvent * makeEventWritable (GstEvent * event);
 
 /* TOC Utilities */
 
-inline gboolean         entryTypeIsAlternative (GstTocEntryType * type) { return GST_TOC_ENTRY_TYPE_IS_ALTERNATIVE(type); }
-inline gboolean         entryTypeIsSequence    (GstTocEntryType * type) { return GST_TOC_ENTRY_TYPE_IS_SEQUENCE(type); }
-inline GstTocEntry *    copyTocEntry           (GstTocEntry * entry)    { return gst_toc_entry_copy(entry); }
-inline GstTocEntry *    makeTocEntryWritable   (GstTocEntry * entry)    { return gst_toc_entry_make_writable(entry); }
-inline GstTocEntry *    tocEntryRef            (GstTocEntry * entry)    { return gst_toc_entry_ref(entry); }
-inline void             tocEntryUnref          (GstTocEntry * entry)    { gst_toc_entry_unref(entry); }
-inline GstToc *         copyToc                (GstToc * toc)           { return gst_toc_copy(toc); }
-inline GstToc *         makeTocWritable        (GstToc * toc)           { return gst_toc_make_writable(toc); }
-inline GstToc *         tocRef                 (GstToc * toc)           { return gst_toc_ref(toc); }
-inline void             tocUnref               (GstToc * toc)           { gst_toc_unref(toc); }
+extern gboolean         entryTypeIsAlternative (GstTocEntryType * type);
+extern gboolean         entryTypeIsSequence    (GstTocEntryType * type);
+extern GstTocEntry *    copyTocEntry           (GstTocEntry * entry);
+extern GstTocEntry *    makeTocEntryWritable   (GstTocEntry * entry);
+extern GstTocEntry *    tocEntryRef            (GstTocEntry * entry);
+extern void             tocEntryUnref          (GstTocEntry * entry);
+extern GstToc *         copyToc                (GstToc * toc);
+extern GstToc *         makeTocWritable        (GstToc * toc);
+extern GstToc *         tocRef                 (GstToc * toc);
+extern void             tocUnref               (GstToc * toc);
 
 /* TagList utilities */
 
-inline gboolean         tagListIsWritable     (GstTagList * tagList)   { return gst_tag_list_is_writable(tagList); }
-inline GstTagList *     makeTagListWritable   (GstTagList * tagList)   { return gst_tag_list_make_writable(tagList); }
+extern gboolean         tagListIsWritable     (GstTagList * tagList);
+extern GstTagList *     makeTagListWritable   (GstTagList * tagList);
 
 /* Object Utilities */
 
-inline GObjectClass *  getGObjectClass         (void * p)                               { return (G_OBJECT_GET_CLASS(p)); }
-inline gboolean        gstElementIsURIHandler  (GstElement * elem)                      { return (GST_IS_URI_HANDLER(elem)); }
-inline gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags) { return (GST_OBJECT_FLAG_IS_SET(obj, flags)); }
+extern GObjectClass *  getGObjectClass         (void * p);
+extern gboolean        gstElementIsURIHandler  (GstElement * elem);
+extern gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags);
 
 /* Element utilities */
 
-inline GstTocSetter *  toTocSetter (GstElement * elem) { return GST_TOC_SETTER(elem); }
-inline GstTagSetter *  toTagSetter (GstElement *elem)  { return GST_TAG_SETTER(elem); }
+extern GstTocSetter *  toTocSetter (GstElement * elem);
+extern GstTagSetter *  toTagSetter (GstElement *elem);
 
 
 /* Misc */
 
-inline gpointer glistNext (GList * list)
-{
-	return g_list_next(list);
-}
+extern gpointer glistNext (GList * list);
 
-inline int sizeOfGCharArray (gchar ** arr)
-{
-	int i;
-	for (i = 0 ; 1 ; i = i + 1) {
-		if (arr[i] == NULL) { return i; };
-	}
-}
+extern int sizeOfGCharArray (gchar ** arr);
 
 #endif

--- a/gst/gst.go.h
+++ b/gst/gst.go.h
@@ -15,7 +15,6 @@ typedef struct _PadDestroyNotifyInfo {
 */
 
 extern GType                  objectGType            (GObject *obj);
-extern GObjectClass *         toGObjectClass         (void *p);
 
 extern GstAllocator *         toGstAllocator         (void *p);
 extern GstBin *               toGstBin               (void *p);
@@ -118,7 +117,6 @@ extern GstTagList *     makeTagListWritable   (GstTagList * tagList);
 
 /* Object Utilities */
 
-extern GObjectClass *  getGObjectClass         (void * p);
 extern gboolean        gstElementIsURIHandler  (GstElement * elem);
 extern gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags);
 


### PR DESCRIPTION
Background: I'm trying to trackdown a C buffer overflow somewhere in my project and really need to be able to use delve/gdb to catch those segfaults.  Unfortunately when trying to produce debug builds the linker falls over when trying to deal with the shim inline functions:

```
go build -o /tmp/___1worker -gcflags all="-N -l" <redacted> #gosetup
# github.com/tinyzimmer/go-gst/gst
/usr/bin/ld: $WORK/b222/_x005.o: in function `_cgo_9fe65b6dd3a1_Cfunc_toGstAllocator':
/tmp/go-build/cgo-gcc-prolog:145: undefined reference to `toGstAllocator'
/usr/bin/ld: $WORK/b222/_x006.o: in function `binParentAddElement':
../../../../../cognitive-i/go-gst/gst/gst_bin.go:10: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x006.o: in function `binParentDeepElementAdded':
../../../../../cognitive-i/go-gst/gst/gst_bin.go:18: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x006.o: in function `binParentDeepElementRemoved':
../../../../../cognitive-i/go-gst/gst/gst_bin.go:26: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x006.o: in function `binParentDoLatency':
../../../../../cognitive-i/go-gst/gst/gst_bin.go:34: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x006.o: in function `binParentElementAdded':
../../../../../cognitive-i/go-gst/gst/gst_bin.go:42: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x006.o:/home/na/workspace/cognitive-i/go-gst/gst/gst_bin.go:50: more undefined references to `toGstBinClass' follow
/usr/bin/ld: $WORK/b222/_x006.o: in function `_cgo_9fe65b6dd3a1_Cfunc_toGstBin':
/tmp/go-build/cgo-gcc-prolog:662: undefined reference to `toGstBin'
/usr/bin/ld: $WORK/b222/_x008.o: in function `_cgo_9fe65b6dd3a1_Cfunc_toGstBinClass':
/tmp/go-build/cgo-gcc-prolog:165: undefined reference to `toGstBinClass'
/usr/bin/ld: $WORK/b222/_x009.o: in function `_cgo_9fe65b6dd3a1_Cfunc_bufferIsWritable':
/tmp/go-build/cgo-gcc-prolog:53: undefined reference to `bufferIsWritable'

...

/usr/bin/ld: $WORK/b222/_x061.o: in function `_cgo_9fe65b6dd3a1_Cfunc_getBufferValue':
/tmp/go-build/cgo-gcc-prolog:89: undefined reference to `getBufferValue'
collect2: error: ld returned 1 exit status

Compilation finished with exit code 2
```

As a fix I've converted all the inline functions into defined symbols and now I am able to produce debug builds that I can run with delve (under Goland).

I'm undecided whether this is this right course of action so opening the PR more as a discussion piece.
