### PR TITLE
Fix #004: build fails on 32 bit architectures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/mattn/go-pointer v0.0.1
-	github.com/tinyzimmer/go-glib v0.0.24
+	github.com/tinyzimmer/go-glib v0.0.25
 )

--- a/gst/audio/gst_audio_channels.go
+++ b/gst/audio/gst_audio_channels.go
@@ -25,7 +25,7 @@ func ChannelPositionsFromMask(channels int, mask uint64) []ChannelPosition {
 		return nil
 	}
 	outsl := make([]ChannelPosition, channels)
-	tmp := (*[1 << 30]C.GstAudioChannelPosition)(unsafe.Pointer(&out))[:channels:channels]
+	tmp := (*[(math.MaxInt32 - 1) / unsafe.Sizeof(C.GST_AUDIO_CHANNEL_POSITION_NONE)]C.GstAudioChannelPosition)(unsafe.Pointer(&out))[:channels:channels]
 	for i, s := range tmp {
 		outsl[i] = ChannelPosition(s)
 	}

--- a/gst/audio/gst_audio_format.go
+++ b/gst/audio/gst_audio_format.go
@@ -5,6 +5,7 @@ package audio
 */
 import "C"
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tinyzimmer/go-glib/glib"
@@ -144,7 +145,7 @@ func RawFormats() []Format {
 	var l C.guint
 	formats := C.gst_audio_formats_raw(&l)
 	out := make([]Format, int(l))
-	tmpslice := (*[1 << 30]C.GstAudioFormat)(unsafe.Pointer(formats))[:l:l]
+	tmpslice := (*[(math.MaxInt32 - 1) / unsafe.Sizeof(C.GST_AUDIO_FORMAT_UNKNOWN)]C.GstAudioFormat)(unsafe.Pointer(formats))[:l:l]
 	for i, s := range tmpslice {
 		out[i] = Format(s)
 	}

--- a/gst/audio/gst_audio_info.go
+++ b/gst/audio/gst_audio_info.go
@@ -10,6 +10,7 @@ gint channels(GstAudioInfo * info)
 */
 import "C"
 import (
+	"math"
 	"runtime"
 	"unsafe"
 
@@ -68,7 +69,7 @@ func (i *Info) BPF() int { return int(i.ptr.bpf) }
 func (i *Info) Positions() []ChannelPosition {
 	l := i.Channels()
 	out := make([]ChannelPosition, int(l))
-	tmpslice := (*[1 << 30]C.GstAudioChannelPosition)(unsafe.Pointer(&i.ptr.position))[:l:l]
+	tmpslice := (*[(math.MaxInt32 - 1) / unsafe.Sizeof(C.GST_AUDIO_CHANNEL_POSITION_NONE)]C.GstAudioChannelPosition)(unsafe.Pointer(&i.ptr.position))[:l:l]
 	for i, s := range tmpslice {
 		out[i] = ChannelPosition(s)
 	}

--- a/gst/c_util.go
+++ b/gst/c_util.go
@@ -5,6 +5,7 @@ import "C"
 
 import (
 	"fmt"
+	"math"
 	"time"
 	"unsafe"
 
@@ -62,7 +63,7 @@ func formatOffset(offset C.gfloat) string {
 // goStrings returns a string slice for an array of size argc starting at the address argv.
 func goStrings(argc C.int, argv **C.gchar) []string {
 	length := int(argc)
-	tmpslice := (*[1 << 30]*C.gchar)(unsafe.Pointer(argv))[:length:length]
+	tmpslice := (*[(math.MaxInt32 - 1) / unsafe.Sizeof((*C.gchar)(nil))]*C.gchar)(unsafe.Pointer(argv))[:length:length]
 	gostrings := make([]string, length)
 	for i, s := range tmpslice {
 		gostrings[i] = C.GoString(s)

--- a/gst/gst_uri_handler_exports.go
+++ b/gst/gst_uri_handler_exports.go
@@ -6,6 +6,7 @@ package gst
 import "C"
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tinyzimmer/go-glib/glib"
@@ -22,7 +23,7 @@ func goURIHdlrGetProtocols(gtype C.GType) **C.gchar {
 	size := C.size_t(unsafe.Sizeof((*C.gchar)(nil)))
 	length := C.size_t(len(protocols))
 	arr := (**C.gchar)(C.malloc(length * size))
-	view := (*[1 << 30]*C.gchar)(unsafe.Pointer(arr))[0:len(protocols):len(protocols)]
+	view := (*[(math.MaxInt32 - 1) / unsafe.Sizeof((*C.gchar)(nil))]*C.gchar)(unsafe.Pointer(arr))[0:len(protocols):len(protocols)]
 	for i, proto := range protocols {
 		view[i] = (*C.gchar)(C.CString(proto))
 	}

--- a/gst/video/gst_video_format.go
+++ b/gst/video/gst_video_format.go
@@ -32,6 +32,7 @@ guint                 formatInfoWSub        (GstVideoFormatInfo * info, guint c)
 import "C"
 import (
 	"image/color"
+	"math"
 	"runtime"
 	"unsafe"
 
@@ -266,7 +267,7 @@ func RawFormats() []Format {
 	var size C.guint
 	formats := C.gst_video_formats_raw(&size)
 	out := make([]Format, uint(size))
-	for i, f := range (*[1 << 30]C.GstVideoFormat)(unsafe.Pointer(formats))[:size:size] {
+	for i, f := range (*[(math.MaxInt32 - 1) / unsafe.Sizeof(C.GST_VIDEO_FORMAT_UNKNOWN)]C.GstVideoFormat)(unsafe.Pointer(formats))[:size:size] {
 		out[i] = Format(f)
 	}
 	return out
@@ -333,7 +334,7 @@ func (f Format) Palette() color.Palette {
 		return nil
 	}
 	paletteBytes := make([]uint8, int64(size))
-	for i, t := range (*[1 << 30]uint8)(ptr)[:int(size):int(size)] {
+	for i, t := range (*[(math.MaxInt32 - 1) / unsafe.Sizeof(uint8(0))]uint8)(ptr)[:int(size):int(size)] {
 		paletteBytes[i] = t
 	}
 	return bytesToColorPalette(paletteBytes)


### PR DESCRIPTION
Fix for builds failing on 32 bit architectures. Similar pull request has been made for go-glib.